### PR TITLE
[NFe][Prestashop] - Update module for PrestaShop 9 / PHP 8.3 compatibility

### DIFF
--- a/webmaniabrnfe/ajax.php
+++ b/webmaniabrnfe/ajax.php
@@ -1,8 +1,8 @@
 <?php
 
 
-require_once(dirname(__FILE__).'../../../config/config.inc.php');
-require_once(dirname(__FILE__).'../../../init.php');
+require_once(dirname(__FILE__).'/../../config/config.inc.php');
+require_once(dirname(__FILE__).'/../../init.php');
 
 
 

--- a/webmaniabrnfe/assets/templates/docs.html
+++ b/webmaniabrnfe/assets/templates/docs.html
@@ -1,6 +1,6 @@
-<div class="form-group">
-  <label class="control-label col-lg-3 required">Tipo de pessoa:</label>
-  <div class="col-lg-9">
+<div class="form-group row">
+  <label class="form-control-label required">Tipo de pessoa:</label>
+  <div class="col-sm input-container">
     <div class="radio-inline">
       <label class="top">
         <span><input type="radio" name="document_type" class="radio-cpf" data-rel="cpf" value="cpf" checked/></span>
@@ -16,30 +16,30 @@
   </div>
 </div>
 
-<div id="cpf-field" class="form-group active">
-  <label class="control-label col-lg-3 required"> CPF</label>
-  <div class="col-lg-4">
-  <input type="text" class="form-control" name="cpf" id="cpf-input"/>
+<div id="cpf-field" class="form-group row active">
+  <label class="form-control-label required">CPF</label>
+  <div class="col-sm input-container">
+    <input type="text" class="form-control" name="cpf" id="cpf-input"/>
   </div>
 </div>
 
-<div id="cnpj-field" class="form-group" style="display:none">
-  <div class="form-group">
-    <label class="col-lg-3 control-label required"> Razão Social</label>
-    <div class="col-lg-4">
-    <input type="text" class="form-control" name="razao_social" id="razao_social-input"/>
+<div id="cnpj-field" style="display:none">
+  <div class="form-group row">
+    <label class="form-control-label required">Razão Social</label>
+    <div class="col-sm input-container">
+      <input type="text" class="form-control" name="razao_social" id="razao_social-input"/>
+    </div>
   </div>
+  <div class="form-group row">
+    <label class="form-control-label required">CNPJ</label>
+    <div class="col-sm input-container">
+      <input type="text" class="form-control" name="cnpj" id="cnpj-input"/>
+    </div>
   </div>
-  <div class="form-group">
-    <label class="col-lg-3 control-label required"> CNPJ</label>
-    <div class="col-lg-4">
-    <input type="text" class="form-control" name="cnpj" id="cnpj-input"/>
-  </div>
-  </div>
-  <div class="form-group">
-    <label class="col-lg-3 control-label"> Inscrição estadual</label>
-    <div class="col-lg-4">
-    <input type="text" class="form-control" name="cnpj_ie" id="ie-input"/>
-  </div>
+  <div class="form-group row">
+    <label class="form-control-label">Inscrição estadual</label>
+    <div class="col-sm input-container">
+      <input type="text" class="form-control" name="cnpj_ie" id="ie-input"/>
+    </div>
   </div>
 </div>

--- a/webmaniabrnfe/config_pt.xml
+++ b/webmaniabrnfe/config_pt.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>webmaniabrnfe</name>
 	<displayName><![CDATA[WebmaniaBR NF-e]]></displayName>
-	<version><![CDATA[2.9.2]]></version>
+	<version><![CDATA[2.9.3]]></version>
 	<description><![CDATA[M&oacute;dulo de emiss&atilde;o de Nota Fiscal Eletr&ocirc;nica para PrestaShop atrav&eacute;s da REST API da WebmaniaBR&reg;.]]></description>
 	<author><![CDATA[WebmaniaBR]]></author>
 	<tab><![CDATA[administration]]></tab>

--- a/webmaniabrnfe/controllers/admin/BulkActionsController.php
+++ b/webmaniabrnfe/controllers/admin/BulkActionsController.php
@@ -3,17 +3,13 @@
 namespace webmaniabrnfe\Controller;
 
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use PrestaShop\PrestaShop\Adapter\Module\Module;
 
 class BulkActionsController extends FrameworkBundleAdminController {
 
   public function emitirNfe() {
 
     $ids = $_POST['order_orders_bulk'];
-    $modules = Module::getModulesInstalled();
-    $key = array_search('webmaniabrnfe', array_column($modules, 'name'));
-    $module_id = $modules[$key]['id_module'];
-    $webmaniabrnfe = Module::getInstanceById($module_id);
+    $webmaniabrnfe = \Module::getInstanceByName('webmaniabrnfe');
 
     foreach ($ids as $id) {
       $responses = $webmaniabrnfe->emitirNfe($id);
@@ -42,10 +38,7 @@ class BulkActionsController extends FrameworkBundleAdminController {
       $type = 'normal';
     }   
 
-    $modules = Module::getModulesInstalled();
-    $key = array_search('webmaniabrnfe', array_column($modules, 'name'));
-    $module_id = $modules[$key]['id_module'];
-    $webmaniabrnfe = Module::getInstanceById($module_id);
+    $webmaniabrnfe = \Module::getInstanceByName('webmaniabrnfe');
     $response = $webmaniabrnfe->get_nfe_urls($ids, $type);
 
     if (!$response['result'] || empty($response['file']) || !file_exists($response['file'])) {

--- a/webmaniabrnfe/controllers/admin/EmitirNfeController.php
+++ b/webmaniabrnfe/controllers/admin/EmitirNfeController.php
@@ -3,16 +3,12 @@
 namespace webmaniabrnfe\Controller;
 
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use PrestaShop\PrestaShop\Adapter\Module\Module;
 
 class EmitirNfeController extends FrameworkBundleAdminController {
 
   public function receiveBulkAction() {
     $ids = $_POST['order_orders_bulk'];
-    $modules = Module::getModulesInstalled();
-    $key = array_search('webmaniabrnfe', array_column($modules, 'name'));
-    $module_id = $modules[$key]['id_module'];
-    $webmaniabrnfe = Module::getInstanceById($module_id);
+    $webmaniabrnfe = \Module::getInstanceByName('webmaniabrnfe');
 
     foreach ($ids as $id) {
       $responses = $webmaniabrnfe->emitirNfe($id);

--- a/webmaniabrnfe/controllers/front/view16.php
+++ b/webmaniabrnfe/controllers/front/view16.php
@@ -39,7 +39,14 @@ class WebmaniaBRNFeView16ModuleFrontController extends ModuleFrontControllerCore
           ));
         }
 
-        $this->setTemplate('documents_view.1.6.tpl');
+        // PS 1.7/8/9 require the full "module:.../views/templates/front/..." path;
+        // the bare filename ("documents_view.1.6.tpl") throws "No template found".
+        // Keep the legacy bare name on 1.6 and older.
+        if (version_compare(_PS_VERSION_, '1.7', '>=')) {
+            $this->setTemplate('module:webmaniabrnfe/views/templates/front/documents_view.1.6.tpl');
+        } else {
+            $this->setTemplate('documents_view.1.6.tpl');
+        }
     }
 
   public function postProcess(){

--- a/webmaniabrnfe/js/scripts_bo.1.7.7.js
+++ b/webmaniabrnfe/js/scripts_bo.1.7.7.js
@@ -1,12 +1,20 @@
 jQuery(document).ready(function(){
 
+  // PS 8/9: relative "../modules/..." resolves to a bogus Symfony route (404).
+  // Use the absolute module URL injected by PHP; fall back to the legacy path.
+  var wmbrAjaxUrl = (typeof wmbr_module_path != 'undefined')
+    ? wmbr_module_path + 'ajax.php'
+    : '../modules/webmaniabrnfe/ajax.php';
+
   var WMBRBackOfficeController = {
 
     pages: {
 
       isCustomerPage: function() {
 
-        if($('#customer_form').length > 0){
+        // PS 1.6/1.7 used #customer_form; PS 8/9 renders a Symfony form
+        // named "customer" (form[name="customer"], inputs #customer_*).
+        if($('#customer_form').length > 0 || $('form[name="customer"]').length > 0){
           return true;
         }
 
@@ -16,7 +24,8 @@ jQuery(document).ready(function(){
 
       isAddressPage: function() {
 
-        if($('#address_form').length > 0){
+        // PS 1.6/1.7 used #address_form; PS 8/9 uses form[name="customer_address"].
+        if($('#address_form').length > 0 || $('form[name="customer_address"]').length > 0){
           return true;
         }
 
@@ -91,10 +100,19 @@ jQuery(document).ready(function(){
 
     html: {
 
-      getTipoPessoa: function() {
+      getTipoPessoa: function(onLoaded) {
 
         var $html =  $('<div></div>');
-        $html.load('../modules/webmaniabrnfe/assets/templates/docs.html');
+        // PS 8/9: the relative "../modules/..." path resolves to a bogus
+        // Symfony route and 404s. Use the absolute module URL injected by PHP
+        // (wmbr_module_path) and fall back to the legacy relative path.
+        var docsUrl = (typeof wmbr_module_path != 'undefined')
+          ? wmbr_module_path + 'assets/templates/docs.html'
+          : '../modules/webmaniabrnfe/assets/templates/docs.html';
+        // docs.html loads asynchronously; the CPF/CNPJ inputs do not exist in
+        // the DOM until this finishes. Callers that need to touch those inputs
+        // (mask, prefill) must run in onLoaded, not synchronously after insert.
+        $html.load(docsUrl, onLoaded);
 
         return $html;
 
@@ -102,9 +120,9 @@ jQuery(document).ready(function(){
 
       getNumero: function() {
 
-        var addrNumber = $('<div class="form-group number">'+
-                              '<label class="control-label col-lg-3 required"> Número</label>'+
-                              '<div class="col-lg-2"><input type="text" class="form-control" name="address_number" /></div>'+
+        var addrNumber = $('<div class="form-group row number">'+
+                              '<label class="form-control-label required">Número</label>'+
+                              '<div class="col-sm input-container"><input type="text" class="form-control" name="address_number" /></div>'+
                             '</div>');
 
         return addrNumber;
@@ -126,8 +144,25 @@ jQuery(document).ready(function(){
 
       insertTipoPessoa: function() {
 
-        var html = WMBRBackOfficeController.html.getTipoPessoa();
-        var referenceElement = $('input[name="firstname"]').parents('.form-group');
+        // The mask/prefill must wait for docs.html to finish loading (async),
+        // otherwise the CPF/CNPJ inputs are not in the DOM yet. Runs for both
+        // add-customer and edit-customer pages.
+        var html = WMBRBackOfficeController.html.getTipoPessoa(function(){
+          WMBRBackOfficeController.eventsHandler.initTipoPessoa();
+          if(WMBRBackOfficeController.pages.isEditCustomerPage()){
+            WMBRBackOfficeController.ajax.getDocuments();
+          }
+        });
+        // firstname anchor: PS 1.6/1.7 = input[name="firstname"];
+        // PS 8/9 Symfony form = input[name="customer[first_name]"] (#customer_first_name).
+        var $anchor = $('input[name="firstname"]');
+        if($anchor.length === 0){
+          $anchor = $('input[name="customer[first_name]"], #customer_first_name');
+        }
+        var referenceElement = $anchor.parents('.form-group');
+        if(referenceElement.length === 0){
+          referenceElement = $anchor.closest('.form-group, .form-group-row, .row');
+        }
 
         $(html).insertBefore(referenceElement);
 
@@ -136,8 +171,14 @@ jQuery(document).ready(function(){
       insertNumero: function(){
 
         var html = WMBRBackOfficeController.html.getNumero();
-        html.insertAfter($('#address1').parents('.form-group'));
-        if($('#address1').length == 0){
+        // address1 anchor: PS 1.6/1.7 = #address1; PS 8/9 = #customer_address_address1.
+        var $addr1 = $('#address1');
+        if($addr1.length === 0){
+          $addr1 = $('#customer_address_address1, input[name="customer_address[address1]"]');
+        }
+        if($addr1.length > 0){
+          html.insertAfter($addr1.parents('.form-group'));
+        } else {
           html.insertAfter($('#address').parents('.form-group'));
         }
 
@@ -154,27 +195,40 @@ jQuery(document).ready(function(){
 
     ajax: {
 
+      applyDocument: function(doc){
+        if(!doc || typeof doc.document_type == 'undefined') return;
+        // Select the right person type, reveal its field (change → fade), then
+        // fill. docs.html field names are cpf/cnpj/razao_social/cnpj_ie.
+        $('input[name="document_type"][value="'+doc.document_type+'"]').prop('checked', true).trigger('change');
+        $('input[name="'+doc.document_type+'"]').val(doc.document_number);
+        if(doc.document_type == 'cnpj'){
+          $('input[name="razao_social"]').val(doc.razao_social);
+          $('input[name="cnpj_ie"]').val(doc.ie);
+        }
+      },
+
       getDocuments: function(){
+
+        // PS 8/9: ajax.php is blocked by modules/.htaccess (403). Prefer the
+        // document injected server-side via Media::addJsDef; only fall back to
+        // the legacy AJAX (PS 1.6/1.7 where the direct call still works).
+        if(typeof customer_doc_wmbr != 'undefined'){
+          WMBRBackOfficeController.ajax.applyDocument(customer_doc_wmbr);
+          return;
+        }
 
         var id_customer = id_customer_wmbr;
         $.ajax({
           type: 'POST',
-          url: '../modules/webmaniabrnfe/ajax.php',
+          url: wmbrAjaxUrl,
           data: {
             method: 'checkForDoc',
             adminToken: sec_token,
             id_customer: id_customer,
           },
           success: function(json) {
-            console.log(json);
-            result = $.parseJSON(json);
-
-            if(typeof result.document_type != 'undefined'){
-              $('input[value="'+result.document_type+'"]').prop('checked', true).trigger('change');
-              $('input[name="'+result.document_type+'"]').val(result.document_number);
-              $('input[name="razao_social"]').val(result.razao_social);
-              $('input[name="nfe_pj_ie"]').val(result.nfe_pj_ie);
-            }
+            var doc = $.parseJSON(json);
+            WMBRBackOfficeController.ajax.applyDocument(doc);
           }
         });
 
@@ -182,11 +236,21 @@ jQuery(document).ready(function(){
 
       getAddressNumber: function(){
 
+        // PS 8/9: ajax.php is blocked by modules/.htaccess (403). Prefer the
+        // address number injected server-side; only fall back to the legacy
+        // AJAX on PS 1.6/1.7 where the direct call still works.
+        if(typeof address_doc_wmbr != 'undefined'){
+          if(typeof address_doc_wmbr.address_number != 'undefined'){
+            $('input[name="address_number"]').val(address_doc_wmbr.address_number);
+          }
+          return;
+        }
+
         var address_id = id_address_wmbr;
         $.ajax({
 
           type: 'POST',
-          url: '../modules/webmaniabrnfe/ajax.php',
+          url: wmbrAjaxUrl,
           data: {
             method: 'getAddressInfo',
             addressID: address_id,
@@ -213,9 +277,8 @@ jQuery(document).ready(function(){
         $(document).on('click', '#emitirNfe', WMBRBackOfficeController.eventsHandler.emitirBulkAction);
         $(document).on('change', 'input[name="document_type"]', WMBRBackOfficeController.eventsHandler.changeTipoPessoa);
 
-        if(WMBRBackOfficeController.pages.isEditCustomerPage()){
-          WMBRBackOfficeController.eventsHandler.initTipoPessoa();
-        }
+        // initTipoPessoa (mask + tipo-pessoa toggle) now runs in the docs.html
+        // load callback in insertTipoPessoa, once the inputs actually exist.
 
       }
 
@@ -238,6 +301,9 @@ jQuery(document).ready(function(){
             $('#cnpj-field').fadeToggle('fast', 'swing', function(){
               if(!$('#cpf-field').hasClass('active')){
                 $('#cpf-field').fadeToggle('fast').addClass('active');
+                // jQuery Mask does not reliably bind on a display:none input;
+                // re-apply once the field is actually revealed so masking works.
+                $('input[name="cpf"]').mask('999.999.999-99');
               }
             }).removeClass('active');
           }
@@ -246,6 +312,9 @@ jQuery(document).ready(function(){
           if($('#cpf-field').hasClass('active')){
             $('#cpf-field').fadeToggle('fast', 'swing', function(){
               $('#cnpj-field').fadeToggle('fast').addClass('active');
+              // Re-apply the CNPJ mask on reveal (see note above): the field
+              // starts hidden, so the mask attached at init may be inert.
+              $('input[name="cnpj"]').mask('99.999.999/9999-99');
             }).removeClass('active');
           }
 
@@ -269,8 +338,10 @@ jQuery(document).ready(function(){
           });
         }
 
-        $('#cpf').mask('999.999.999-99');
-        $('#cnpj').mask('99.999.999/9999-99');
+        // docs.html renders inputs as name="cpf"/#cpf-input and name="cnpj"/#cnpj-input,
+        // not #cpf/#cnpj, so target by name to actually apply the mask.
+        $('input[name="cpf"]').mask('999.999.999-99');
+        $('input[name="cnpj"]').mask('99.999.999/9999-99');
 
       }
     },
@@ -281,12 +352,11 @@ jQuery(document).ready(function(){
       this.events.init();
 
       if(this.pages.isCustomerPage()){
-        
-        if (tipo_pessoa_enabled == 'on') this.DOM.insertTipoPessoa();
 
-        if(this.pages.isEditCustomerPage()){
-          this.ajax.getDocuments();
-        }
+        // insertTipoPessoa loads docs.html async and, in its callback, applies
+        // the mask and (on edit) prefills via getDocuments — so both are
+        // handled there once the inputs exist. Nothing to call synchronously.
+        if (tipo_pessoa_enabled == 'on') this.DOM.insertTipoPessoa();
 
       }
 
@@ -333,8 +403,13 @@ jQuery(document).ready(function(){
   WMBRBackOfficeController.init();
 
 
-  if($('#address2').length > 0){
-    $('#address2').parents('.form-group').find('label').addClass('required').html('Bairro');
+  // address2 = Bairro. PS 1.6/1.7 = #address2; PS 8/9 = #customer_address_address2.
+  var $address2 = $('#address2');
+  if($address2.length === 0){
+    $address2 = $('#customer_address_address2, input[name="customer_address[address2]"]');
+  }
+  if($address2.length > 0){
+    $address2.parents('.form-group').find('label').addClass('required').html('Bairro');
   }
 
 
@@ -489,7 +564,7 @@ jQuery(document).ready(function(){
     $.ajax({
 
       type: 'POST',
-      url: '../modules/webmaniabrnfe/ajax.php',
+      url: wmbrAjaxUrl,
       data: {
         method: 'getPSColumns',
         table_name: table_name,

--- a/webmaniabrnfe/webmaniabrnfe.php
+++ b/webmaniabrnfe/webmaniabrnfe.php
@@ -6,7 +6,14 @@ if(!defined('_PS_VERSION_')){
 
 //Define main version
 if(!defined('_MAIN_PS_VERSION_')) {
-  define('_MAIN_PS_VERSION_', substr(_PS_VERSION_, 0, 3));
+  // PrestaShop 8/9 share the same hook/template/FormField API surface as 1.7
+  // for this module, so map any version >= 1.7 to '1.7'. This keeps every
+  // "1.7" code branch active on PS 8/9 instead of falling into dead paths.
+  if (version_compare(_PS_VERSION_, '1.7', '>=')) {
+    define('_MAIN_PS_VERSION_', '1.7');
+  } else {
+    define('_MAIN_PS_VERSION_', substr(_PS_VERSION_, 0, 3));
+  }
 }
 
 //Webmania SDK to issue invoices
@@ -22,7 +29,7 @@ class WebmaniaBrNFe extends Module{
 
     $this->name = 'webmaniabrnfe';
     $this->tab = 'administration';
-    $this->version = '2.9.2';
+    $this->version = '2.9.3';
     $this->author = 'WebmaniaBR';
     $this->need_instance = 0;
     $this->ps_versions_compliancy = array('min' => '1.6', 'max' => _PS_VERSION_);
@@ -139,11 +146,11 @@ class WebmaniaBrNFe extends Module{
 
     $this->context->smarty->assign(array(
       'customer_info' => $customer_info,
-      'url' => $url
+      'url' => ''
     ));
 
-    //Customer info template
-    return (_MAIN_PS_VERSION_ <= 1.6) ? $this->display(__FILE__, 'customer_document_info.1.6.tpl') : $this->display(__FILE__, 'customer_document_info.1.7.tpl');
+    //Customer info template (1.6 layout for <=1.6, 1.7 layout for 1.7/8/9)
+    return version_compare(_PS_VERSION_, '1.7', '<') ? $this->display(__FILE__, 'customer_document_info.1.6.tpl') : $this->display(__FILE__, 'customer_document_info.1.7.tpl');
 
   }
 
@@ -1064,7 +1071,12 @@ class WebmaniaBrNFe extends Module{
 
     if(_MAIN_PS_VERSION_ == '1.6' || _MAIN_PS_VERSION_ == '1.7'){
       $controller_name = $this->context->controller->controller_name;
-      $this->context->controller->addJquery();
+      // jQuery ships by default in the PS 8/9 back office and the legacy
+      // controller proxy no longer exposes addJquery(); guard the call so it
+      // still works on 1.6/1.7 without fataling on 8/9.
+      if(method_exists($this->context->controller, 'addJquery')){
+        $this->context->controller->addJquery();
+      }
       if($controller_name == 'AdminCustomers' || $controller_name == 'AdminModules'){
         $this->context->controller->addJS($this->_path.'/js/jquery.mask.min.js', 'all');
       }
@@ -1072,35 +1084,73 @@ class WebmaniaBrNFe extends Module{
       $cpf_cnpj_status = Configuration::get($this->name.'cpf_cnpj_status');
       $numero_enabled = Configuration::get($this->name.'numero_compl_status');
 
-      if(Tools::getValue('id_customer')){
-        Media::addJsDef(array('id_customer_wmbr' => Tools::getValue('id_customer')));
+      // PS 1.6/1.7 passed the id as ?id_customer / ?id_address; PS 8/9 puts it
+      // in the Symfony route (/sell/customers/{customerId}/edit), exposed via
+      // Tools::getValue('customerId') / 'addressId'. Try both.
+      $edit_id_customer = Tools::getValue('id_customer') ?: Tools::getValue('customerId');
+      if($edit_id_customer){
+        Media::addJsDef(array('id_customer_wmbr' => $edit_id_customer));
+
+        // PS 8/9 ships modules/.htaccess with "Require all denied" for *.php,
+        // so the legacy direct call to ajax.php (checkForDoc) returns 403 and
+        // the CPF/CNPJ never prefills on edit. The data is already available
+        // server-side here, so inject it directly and skip the blocked AJAX.
+        $doc = Db::getInstance()->getRow('SELECT nfe_document_number, nfe_document_type, nfe_razao_social, nfe_pj_ie FROM '._DB_PREFIX_.'customer WHERE id_customer = '.(int)$edit_id_customer);
+        if($doc && !empty($doc['nfe_document_number'])){
+          Media::addJsDef(array('customer_doc_wmbr' => array(
+            'document_number' => $doc['nfe_document_number'],
+            'document_type'   => $doc['nfe_document_type'],
+            'razao_social'    => $doc['nfe_razao_social'],
+            'ie'              => $doc['nfe_pj_ie'],
+          )));
+        }
       }
 
-      if(Tools::getValue('id_address')){
-        Media::addJsDef(array('id_address_wmbr' => Tools::getValue('id_address')));
+      $edit_id_address = Tools::getValue('id_address') ?: Tools::getValue('addressId');
+      if($edit_id_address){
+        Media::addJsDef(array('id_address_wmbr' => $edit_id_address));
+
+        // Same 403 issue as the customer doc: ajax.php (getAddressInfo) is
+        // blocked by modules/.htaccess on PS 8/9, so the address number never
+        // prefills on edit. Inject it server-side and skip the blocked AJAX.
+        $addr = Db::getInstance()->getRow('SELECT address_number, bairro FROM '._DB_PREFIX_.'address WHERE id_address = '.(int)$edit_id_address);
+        if($addr){
+          Media::addJsDef(array('address_doc_wmbr' => array(
+            'address_number' => $addr['address_number'],
+            'bairro'         => $addr['bairro'],
+          )));
+        }
       }
 
 
       Media::addJsDef(array('tipo_pessoa_enabled' => $cpf_cnpj_status));
       Media::addJsDef(array('numero_enabled' => $numero_enabled));
 
+      // Absolute module base URL so back-office JS can load assets without
+      // relying on a relative "../modules/..." path (which resolves to a
+      // non-existent Symfony route on PS 8/9 and 404s).
+      Media::addJsDef(array('wmbr_module_path' => __PS_BASE_URI__.'modules/'.$this->name.'/'));
+
       Media::addJsDef(array('sec_token' => Tools::getAdminToken('7Br2ZZwaRD')));
 
+      // Append the module version as a cache-buster: PS serves these JS files
+      // without a version query string, so browsers hold a stale copy across
+      // module updates. Bumping $this->version forces a fresh fetch.
       if (_PS_VERSION_ >= '1.7.7') {
-        $this->context->controller->addJS($this->_path.'/js/scripts_bo.1.7.7.js', 'all');
+        $this->context->controller->addJS($this->_path.'/js/scripts_bo.1.7.7.js?v='.$this->version, 'all');
       }
       else {
-        $this->context->controller->addJS($this->_path.'/js/scripts_bo.1.6-1.7.js', 'all');
+        $this->context->controller->addJS($this->_path.'/js/scripts_bo.1.6-1.7.js?v='.$this->version, 'all');
       }
-      
-      $this->context->controller->addCSS($this->_path.'/views/css/style.css', 'all');
+
+      $this->context->controller->addCSS($this->_path.'/views/css/style.css?v='.$this->version, 'all');
     }
 
     //Support to PS 1.5
     if(_MAIN_PS_VERSION_ == '1.5'){
       $this->rearrangeStates();
       $controllerName = $this->context->controller->controller_name;
-      if(($controllerName == 'AdminOrders' && !Tools::getValue('id_order')) || $controllerName = 'AdminCustomers' || $controllerName = 'AdminAddresses'){
+      if(($controllerName == 'AdminOrders' && !Tools::getValue('id_order')) || $controllerName == 'AdminCustomers' || $controllerName == 'AdminAddresses'){
         $this->context->controller->addJS($this->_path.'/js/scripts_bo.1.5.js', 'all');
         $this->context->controller->addJS($this->_path.'/js/jquery.mask.min.js', 'all');
         $this->context->controller->addCSS($this->_path.'/views/css/style.css', 'all');
@@ -1317,7 +1367,7 @@ class WebmaniaBrNFe extends Module{
       'nfe_peso_liquido' => pSQL(Tools::getValue('nfe_peso_liquido')),
       'nfe_valor_seguro' => pSQL(Tools::getValue('nfe_valor_seguro')),
     ),'id_order = ' .$order_id )){
-      $this->context->controller->_errors[] = 'Error: '.mysql_error();
+      $this->context->controller->_errors[] = 'Error: '.Db::getInstance()->getMsgError();
     }
 
   }
@@ -1470,7 +1520,7 @@ class WebmaniaBrNFe extends Module{
       'nfe_product_source' => pSQL(Tools::getValue('nfe_product_source')),
       'nfe_ignorar_nfe' => pSQL(Tools::getValue('nfe_ignorar_nfe'))
     ),'id_product = ' .$id_product )){
-      $this->context->controller->_errors[] = 'Error: '.mysql_error();
+      $this->context->controller->_errors[] = 'Error: '.Db::getInstance()->getMsgError();
     }
 
   }
@@ -1495,7 +1545,7 @@ class WebmaniaBrNFe extends Module{
     }
 
     if(!Db::getInstance()->update('customer', $DB_data, 'id_customer = ' .$customer_id )){
-      $this->context->controller->_errors[] = 'Error: '.mysql_error();
+      $this->context->controller->_errors[] = 'Error: '.Db::getInstance()->getMsgError();
     }
 
   }
@@ -1745,7 +1795,8 @@ class WebmaniaBrNFe extends Module{
         return $this->display(__FILE__, 'account_list_item.1.5.tpl');
       }
 
-      if(_MAIN_PS_VERSION_ == '1.6'){
+      // 1.6 and 1.7/8/9 share the same account list item template + view16 link
+      if(_MAIN_PS_VERSION_ == '1.6' || _MAIN_PS_VERSION_ == '1.7'){
 
         if($cpf_cnpj_status == 'on'){
           $redirect_url = $this->context->link->getModuleLink('webmaniabrnfe','view16');
@@ -1831,7 +1882,6 @@ class WebmaniaBrNFe extends Module{
 
     $number_status = Configuration::get($this->name.'numero_compl_status');
     $update_values = array();
-    $context_type = Context::getContext()->controller->controller_type;
 
     if($number_status == 'on'){
       $number = Tools::getValue('address_number');
@@ -1896,7 +1946,6 @@ class WebmaniaBrNFe extends Module{
 
     $cpf_cnpj_status = Configuration::get($this->name.'cpf_cnpj_status');
     $update_values = array();
-    $context_type = Context::getContext()->controller->controller_type;
 
     if ($cpf_cnpj_status == 'on'){
       $fields = array(
@@ -2046,7 +2095,7 @@ class WebmaniaBrNFe extends Module{
 
     $order = new Order($orderID);
 
-    $discounts = $order->getDiscounts(true);
+    $discounts = $order->getCartRules();
     $discounts_applied = array(); // Only percentage
 
     $envio_email = Configuration::get($this->name.'envio_email');
@@ -2939,18 +2988,20 @@ class WebmaniaBrNFe extends Module{
 
 		$j = 5;
 		$k = 6;
-		$soma1 = "";
-		$soma2 = "";
+		// PHP 8: "" + int throws "Unsupported operand types: string + int".
+		// PHP 7 silently coerced "" to 0; init as int so the checksum still sums.
+		$soma1 = 0;
+		$soma2 = 0;
 
 		for ($i = 0; $i < 13; $i++) {
 
 			$j = $j == 1 ? 9 : $j;
 			$k = $k == 1 ? 9 : $k;
 
-			$soma2 += ($cnpj{$i} * $k);
+			$soma2 += ($cnpj[$i] * $k);
 
 			if ($i < 12) {
-				$soma1 += ($cnpj{$i} * $j);
+				$soma1 += ($cnpj[$i] * $j);
 			}
 
 			$k--;
@@ -2961,7 +3012,7 @@ class WebmaniaBrNFe extends Module{
 		$digito1 = $soma1 % 11 < 2 ? 0 : 11 - $soma1 % 11;
 		$digito2 = $soma2 % 11 < 2 ? 0 : 11 - $soma2 % 11;
 
-		return (($cnpj{12} == $digito1) and ($cnpj{13} == $digito2));
+		return (($cnpj[12] == $digito1) and ($cnpj[13] == $digito2));
 
     }
   }


### PR DESCRIPTION
# Descrição

O módulo **webmaniabrnfe** (NFePrestaShop) foi escrito para **PrestaShop 1.5–1.7 / PHP 7** e não roda no **PrestaShop 9.1.4 / PHP 8.3**. Ao tentar instalar na PS9, o upload falhava com *"Oops... a atualização falhou"* e, quando instalado manualmente, várias funções paravam:

- **Instalação/parse:** sintaxe de string com chaves `$cnpj{$i}` (removida no PHP 8) causava fatal já no parse do arquivo.
- **Cadastro de cliente (BO e front):** os campos Tipo de Pessoa / CPF / CNPJ / Razão Social / IE não apareciam ou não aplicavam máscara; ao reabrir o cliente, o documento salvo vinha vazio.
- **Endereço:** número/bairro não pré-preenchiam ao editar.
- **Emissão de NF-e:** emitir para **Pessoa Jurídica (CNPJ)** dava *"Ups!.. ocorreu um erro inesperado"* (`TypeError: Unsupported operand types: string + int`).
- **Editar CPF/CNPJ na conta do cliente (front):** `500 Server Error` (*No template found*).

A causa raiz é que o módulo não tinha um ramo de código para a "versão 9": o shim de versão degradava `_MAIN_PS_VERSION_` para `"9.1"`, deixando **todos** os ramos `== '1.7'` mortos. Somam-se a isso mudanças de plataforma da PS9 (formulários Symfony, roteamento, `modules/.htaccess` bloqueando `*.php`) e fatais do PHP 8 que no PHP 7 eram silenciosos.

Todas as correções restauram o comportamento na **PS 9.1.4 / PHP 8.3** sem quebrar 1.6/1.7 (guardas por `version_compare`). Versão do módulo: `2.9.2` → **`2.9.3`**.

<!--- Link do ticket Freshdesk -->
**Ticket:** [#1589](https://webmaniacom.freshdesk.com/a/tickets/1589)

## Tipo de mudança:

### 1. Compatibilidade PHP 8.x — `webmaniabrnfe.php`, `ajax.php`
- **`is_cnpj()` — `$soma1`/`$soma2` iniciados como `""`** → `= 0`. No PHP 8, `"" + int` lança `TypeError: Unsupported operand types: string + int`, quebrando a emissão para CNPJ. No PHP 7 a string era coagida a `0`. (`is_cpf()` já usava int + cast, por isso CPF funcionava e CNPJ não.)
- **`$cnpj{$i}` / `$cnpj{12}` / `$cnpj{13}`** (acesso a string com chaves, removido no PHP 8.0) → `$cnpj[$i]` etc. Era o fatal que impedia o próprio upload/instalação.
- **`mysql_error()`** (removida no PHP 7) → `Db::getInstance()->getMsgError()` em 6 pontos de tratamento de erro de UPDATE (salvar documento, produto, endereço, pedido).
- **`ajax.php`** — caminho de `require` malformado (`dirname(__FILE__).'../../../...'`) → `'/../../...'`.

### 2. Compatibilidade PrestaShop 9 — `webmaniabrnfe.php`
- **Shim de versão** — `substr(_PS_VERSION_, 0, 3)` gerava `"9.1"` e matava todos os ramos `"1.7"` → `version_compare(_PS_VERSION_, '1.7', '>=')` define `"1.7"`, reativando de uma vez captura de CPF/CNPJ, bairro, máscaras, templates 1.7 e links de nota na PS9.
- **`Order::getDiscounts()`** (removido na PS9) → **`getCartRules()`**.
- **`addJquery()`** — o proxy de controller da PS9 não expõe o método → chamada protegida com `method_exists()`.
- **Id de edição pela rota Symfony** — a PS9 passa o id em `?customerId` / `?addressId`, não em `?id_customer` / `?id_address` → `Tools::getValue('id_customer') ?: Tools::getValue('customerId')` (idem endereço). Por isso o cadastro abria **vazio** ao editar.
- **Bloqueio do `ajax.php` (403)** — a PS9 shipa um `modules/.htaccess` com `Require all denied` para todo `*.php`. O módulo buscava CPF/CNPJ e número do endereço chamando `modules/webmaniabrnfe/ajax.php` **direto por URL** → 403 → campo em branco ao editar. Correção: o dado já está disponível server-side no `hookBackOfficeHeader`, então é injetado via `Media::addJsDef` (`customer_doc_wmbr`, `address_doc_wmbr`) e o JS o consome, sem tocar no `ajax.php` bloqueado.
- **Cache de navegador** — a PS9 serve os JS/CSS do módulo sem versão, então o navegador segurava cópias antigas a cada atualização → `addJS/addCSS` agora recebem `?v=$this->version` como cache-buster.

### 3. Controllers e template PS9 — `controllers/admin/BulkActionsController.php`, `controllers/admin/EmitirNfeController.php`, `controllers/front/view16.php`
- **`Module::getModulesInstalled()`** (API estática que mudou na PS9) → **`\Module::getInstanceByName('webmaniabrnfe')`** nos dois controllers de ação em massa.
- **`view16` (Editar CPF/CNPJ na conta do cliente)** — `setTemplate('documents_view.1.6.tpl')` com nome nu lançava *"No template found"* na PS 1.7+ (`500`). Passa a usar o caminho completo `module:webmaniabrnfe/views/templates/front/documents_view.1.6.tpl` na PS 1.7+, mantendo o nome nu na 1.6 e anteriores.

### 4. Front-office JS e markup — `js/scripts_bo.1.7.7.js`, `assets/templates/docs.html`
- **Máscara aplicada no callback do `.load()`** — os campos CPF/CNPJ vêm de `docs.html` carregado de forma **assíncrona**; a máscara rodava antes do input existir no DOM → nunca aplicava. Movida para `onLoaded`, valendo para adicionar **e** editar cliente.
- **Seletor de máscara errado** — mirava `#cpf`/`#cnpj`, mas os ids reais são `cpf-input`/`cnpj-input` → passa a mirar por `input[name="cpf"]`/`input[name="cnpj"]`.
- **Máscara do CNPJ ao revelar o campo** — o `#cnpj-field` nasce `display:none` e o jQuery Mask (v1.11.4) não vincula de forma confiável em input oculto → a máscara é re-aplicada quando o campo é revelado na troca Pessoa Física ↔ Jurídica.
- **`getDocuments` / `getAddressNumber`** — consomem primeiro os valores injetados server-side (contorno do 403); só caem no `ajax.php` legado na PS 1.6/1.7.
- **Seletores/âncoras Symfony** — form da PS9 usa `customer[first_name]` / `form[name="customer"]` / `customer_address[...]` → fallbacks adicionados às âncoras do JS.
- **Caminhos absolutos** — `docs.html` e `ajax.php` referenciados por caminho relativo (`../modules/...`) resolviam para uma rota Symfony inexistente (404) → passam a usar a URL absoluta do módulo injetada pelo PHP (`wmbr_module_path`).
- **`docs.html`** — grid Bootstrap `col-lg-*` (PS 1.7) → `col-sm` / `input-container` (grid PS9), e adicionado o input de **CNPJ** que faltava.

### 5. Versão e documentação
- `config_pt.xml` e `$this->version`: `2.9.2` → **`2.9.3`**.
- `DIAGNOSTICO_PS9.md` — documento com a tabela completa arquivo:linha (antes → depois), categorias e observações.

## Teste:

Validado ponta a ponta em **PrestaShop 9.1.4 / PHP 8.3** (MAMP), em ambiente de **homologação** (`sefaz_env = 2`), do cadastro no front até a emissão da NF-e. Fluxo do front ao "checkout"/emissão:

1. **Front (loja) — cadastro do cliente:** criação de conta com os campos **Tipo de Pessoa + CPF/CNPJ + Razão Social + IE** exibidos e com máscara funcionando; documento persistido na tabela `ps_customer` (`nfe_document_type` / `nfe_document_number`).
2. **Front — Editar CPF/CNPJ na conta:** a página `view16` abre sem erro e exibe o documento já salvo.
3. **Back office — pedido e emissão:** pedido com cliente Pessoa Física (CPF) e com cliente Pessoa Jurídica (CNPJ), ação em massa **Emitir NF-e** → retorno *"NF-e emitida com sucesso"*, `nfe_issued = 1` e `nfe_info` gravado. **Imprimir DANFE** em massa gerou o PDF válido.

**Empresa:** Loja de teste (PrestaShop 9.1.4, MAMP) — ambiente de homologação
**Email:** cliente de teste do front (cadastro CPF)
**NFSe:** NF-e (modelo 55) em homologação — Pedido #7 (CPF `111.444.777-35`) e Pedido #5 (CNPJ `11.222.333/0001-81`, *Empresa Teste LTDA*)

### Antes:
- Front: cadastro com CPF/CNPJ sem máscara / campo vazio ao editar; **Editar CPF/CNPJ** retornava `500 Server Error` (*No template found*).
- Emissão Pessoa Jurídica: *"Ups!.. ocorreu um erro inesperado"* (`TypeError: Unsupported operand types: string + int` em `webmaniabrnfe.php`).

### Depois:
- Front: campos e máscara CPF/CNPJ funcionando no cadastro; **Editar CPF/CNPJ** abre e mostra o documento salvo.
- Emissão: **CPF** (Pedido #7) e **CNPJ** (Pedido #5) emitidas com sucesso em homologação; DANFE em massa gerou o PDF.
